### PR TITLE
Fixed BBox.top_left to nolonger return bottom_left.

### DIFF
--- a/imantics/annotation.py
+++ b/imantics/annotation.py
@@ -502,7 +502,7 @@ class BBox:
             [ ]------[ ]
         
         """
-        return self._xmin, self._ymax
+        return self._xmin, self._ymin
         
     @property
     def bottom_right(self):


### PR DESCRIPTION
BBox.top_left was returning bottom_left. Now returns the correct corner.