### PR TITLE
Fix image ids being all identical in from_folder

### DIFF
--- a/imantics/image.py
+++ b/imantics/image.py
@@ -24,12 +24,15 @@ class Image(Semantic):
 
         :returns: list of :class:`Image`'s
         """
+        image_id = 0
         images = []
         for path, _, files in os.walk(directory):
             for name in files:
                 file_path = os.path.join(path, name)
                 if file_path.lower().endswith(cls.FORMATS):
                     images.append(cls.from_path(file_path))
+                    images[image_id].id = image_id
+                    image_id += 1
         
         return images
 


### PR DESCRIPTION
Ensure images returned by from_folder all have a unique id. This is related to #24 