### PR TITLE
pycocotools workaround when mask have only 4 numbers

### DIFF
--- a/imantics/annotation.py
+++ b/imantics/annotation.py
@@ -298,8 +298,8 @@ class Annotation(Semantic):
                     x = (x2 + x1) // 2
                     y = int(round(a*x + b))
 
-                new_point = polygon[:2] + [x, y] + polygon[2:]
-                annotation['segmentation'][i] = new_point
+                new_segmentation = polygon[:2] + [x, y] + polygon[2:]
+                annotation['segmentation'][i] = new_segmentation
 
         if include:
             image = category = {}

--- a/imantics/annotation.py
+++ b/imantics/annotation.py
@@ -286,10 +286,17 @@ class Annotation(Semantic):
                 # 4 value segmentation mask is a bounding box
                 polygon = annotation['segmentation'][i]
                 x1, y1, x2, y2 = polygon
-                a = (y2 - y1) / (x2 - x1)
-                b = y1 - a*x1
-                x = (x2 + x1) // 2
-                y = int(round(a*x + b))
+                if x2 == x1:
+                    x = x1
+                    y = (y2 + y1) // 2
+                elif y2 == y1:
+                    x = (x2 + x1) // 2
+                    y = y1
+                else:
+                    a = (y2 - y1) / (x2 - x1)
+                    b = y1 - a*x1
+                    x = (x2 + x1) // 2
+                    y = int(round(a*x + b))
 
                 new_segmentation = polygon[:2] + [x, y] + polygon[2:]
                 annotation['segmentation'][i] = new_segmentation

--- a/imantics/annotation.py
+++ b/imantics/annotation.py
@@ -298,8 +298,8 @@ class Annotation(Semantic):
                     x = (x2 + x1) // 2
                     y = int(round(a*x + b))
 
-                new_segmentation = polygon[:2] + [x, y] + polygon[2:]
-                annotation['segmentation'][i] = new_segmentation
+                new_point = polygon[:2] + [x, y] + polygon[2:]
+                annotation['segmentation'][i] = new_point
 
         if include:
             image = category = {}

--- a/imantics/annotation.py
+++ b/imantics/annotation.py
@@ -279,18 +279,20 @@ class Annotation(Semantic):
 
         }
 
-        if len(annotation['segmentation']) == 4:
-            # create another point in the middle of segmentation to
-            # avoid bug when using pycocotools, which thinks that a
-            # 4 value segmentation mask is a bounding box
-            x1, y1, x2, y2 = annotation['segmentation']
-            a = (y2 - y1) / (x2 - x1)
-            b = y1 - a*x1
-            x = (x2 + x1) // 2
-            y = int(round(a*x + b))
+        for i in range(len(annotation['segmentation'])):
+            if len(annotation['segmentation'][i]) == 4:
+                # create another point in the middle of segmentation to
+                # avoid bug when using pycocotools, which thinks that a
+                # 4 value segmentation mask is a bounding box
+                polygon = annotation['segmentation'][i]
+                x1, y1, x2, y2 = polygon
+                a = (y2 - y1) / (x2 - x1)
+                b = y1 - a*x1
+                x = (x2 + x1) // 2
+                y = int(round(a*x + b))
 
-            new_segmentation = annotation['segmentation'][:2] + [x, y] + annotation['segmentation'][2:]
-            annotation['segmentation'] = new_segmentation
+                new_segmentation = polygon[:2] + [x, y] + polygon[2:]
+                annotation['segmentation'][i] = new_segmentation
 
         if include:
             image = category = {}

--- a/imantics/annotation.py
+++ b/imantics/annotation.py
@@ -279,8 +279,12 @@ class Annotation(Semantic):
 
         }
 
-        for i in range(len(annotation['segmentation'])):
-            if len(annotation['segmentation'][i]) == 4:
+        i = 0
+        while i < len(annotation['segmentation']):
+            if len(annotation['segmentation'][i]) == 2:
+                # discard segmentation that is only a point
+                annotation['segmentation'].pop(i)
+            elif len(annotation['segmentation'][i]) == 4:
                 # create another point in the middle of segmentation to
                 # avoid bug when using pycocotools, which thinks that a
                 # 4 value segmentation mask is a bounding box
@@ -300,6 +304,7 @@ class Annotation(Semantic):
 
                 new_segmentation = polygon[:2] + [x, y] + polygon[2:]
                 annotation['segmentation'][i] = new_segmentation
+                i += 1
 
         if include:
             image = category = {}


### PR DESCRIPTION
[Internally pycocotools](https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/_mask.pyx#L292) handles a segmentation mask with only 4 numbers (x1, y1, x2, y2) as it was a bounding box (x, y, h, w), which was also mentioned [here](https://github.com/cocodataset/cocoapi/issues/139). This patch handles this case by adding an intermediate point to the mask, so it now has 6 numbers and can be handled the right way by the pycocotools api,