### PR TITLE
Removing segmentations with only one point

### DIFF
--- a/imantics/annotation.py
+++ b/imantics/annotation.py
@@ -290,6 +290,7 @@ class Annotation(Semantic):
                 # 4 value segmentation mask is a bounding box
                 polygon = annotation['segmentation'][i]
                 x1, y1, x2, y2 = polygon
+
                 if x2 == x1:
                     x = x1
                     y = (y2 + y1) // 2

--- a/imantics/annotation.py
+++ b/imantics/annotation.py
@@ -284,6 +284,7 @@ class Annotation(Semantic):
             if len(annotation['segmentation'][i]) == 2:
                 # discard segmentation that is only a point
                 annotation['segmentation'].pop(i)
+                i -= 1
             elif len(annotation['segmentation'][i]) == 4:
                 # create another point in the middle of segmentation to
                 # avoid bug when using pycocotools, which thinks that a
@@ -305,7 +306,8 @@ class Annotation(Semantic):
 
                 new_segmentation = polygon[:2] + [x, y] + polygon[2:]
                 annotation['segmentation'][i] = new_segmentation
-                i += 1
+
+            i += 1
 
         if include:
             image = category = {}


### PR DESCRIPTION
Removing segmentations that have only one point, since they are too small to consider and also will generate erroneous behavior when used by pycocotools